### PR TITLE
fix: release_suse_generic renamed to release_linux

### DIFF
--- a/kanidm.spec
+++ b/kanidm.spec
@@ -83,7 +83,7 @@ Documentation for using and configuring Kanidm.
 
 %build
 # Set our build profile, this will autodetect our cpu flags
-export KANIDM_BUILD_PROFILE=release_suse_generic
+export KANIDM_BUILD_PROFILE=release_linux
 # Show linking info for debugging
 # export RUSTC_LOG='rustc_codegen_ssa::back::link=info'
 # Dump the target features of this cpu.


### PR DESCRIPTION
The `release_suse_generic` build profile was renamed to `release_linux` with kanidm/kanidm#2907. This fixes the `KANIDM_BUILD_PROFILE` environment variable for the build.

You might need to fix up a couple of other things with the spec file as I got some other errors at the end of `mock` build:

```
RPM build errors:
error: Installed (but unpackaged) file(s) found:
   /usr/lib64/libnss_kanidm.so
    source_date_epoch_from_changelog set but %changelog is missing
    File listed twice: /usr/share/kanidm/ui/pkg/external
    File listed twice: /usr/share/kanidm/ui/pkg/external/bootstrap.bundle.min.js
    File listed twice: /usr/share/kanidm/ui/pkg/external/bootstrap.bundle.min.js.br
    File listed twice: /usr/share/kanidm/ui/pkg/external/bootstrap.bundle.min.js.map
    File listed twice: /usr/share/kanidm/ui/pkg/external/bootstrap.bundle.min.js.map.br
    File listed twice: /usr/share/kanidm/ui/pkg/external/bootstrap.min.css
    File listed twice: /usr/share/kanidm/ui/pkg/external/bootstrap.min.css.br
    File listed twice: /usr/share/kanidm/ui/pkg/external/bootstrap.min.css.map
    File listed twice: /usr/share/kanidm/ui/pkg/external/bootstrap.min.css.map.br
    File listed twice: /usr/share/kanidm/ui/pkg/external/confetti.js
    File listed twice: /usr/share/kanidm/ui/pkg/external/viz.js
    File listed twice: /usr/share/kanidm/ui/pkg/external/viz.js.br
    Installed (but unpackaged) file(s) found:
   /usr/lib64/libnss_kanidm.so
```

Thanks for putting this together! I was looking to install Kanidm on my home server and found your copr project. I noticed the builds hadn't succeeded since v1.3.0 and decided to dig into it.